### PR TITLE
mods.sh: use $@ instead of $1

### DIFF
--- a/mods.sh
+++ b/mods.sh
@@ -113,7 +113,7 @@ function run() {
 }
 
 MODS="mods/cheat/release.properties mods/cheat-autoexec/release.properties mods/cheat-keys/release.properties mods/cheat-quest/release.properties"
-COMMANDS="${1:-build install run}"
+COMMANDS="${@:-build install run}"
 
 for MOD in ${MODS}; do
     for COMMAND in ${COMMANDS}; do


### PR DESCRIPTION
After this change
` ./mods.sh build install`
runs both build and install stages instead of ignoring the second argument, which is more convenient then having to pass both stages in one argument with:
` ./mods.sh 'build install'`